### PR TITLE
Add GitHub Pages deployment workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,42 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v4
+
+      - name: Upload site artifact
+        uses: actions/upload-pages-artifact@v2
+        with:
+          path: ./
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs: build
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v2

--- a/README.md
+++ b/README.md
@@ -1,1 +1,12 @@
 # daiki
+
+This repository contains a static website that can be published automatically to GitHub Pages. The deployment workflow in [`.github/workflows/deploy.yml`](.github/workflows/deploy.yml) uploads the contents of the repository and publishes them to the `github-pages` environment whenever changes are pushed to the `main` branch or when the workflow is run manually.
+
+## Deploying to GitHub Pages
+
+1. Open the **Settings** tab of your GitHub repository and navigate to **Pages**.
+2. Under **Build and deployment**, choose **GitHub Actions** as the source.
+3. Save the settings if prompted.
+4. Push a commit to the `main` branch or trigger the **Deploy to GitHub Pages** workflow manually from the **Actions** tab to publish the site.
+
+The workflow uses the recommended `actions/configure-pages`, `actions/upload-pages-artifact`, and `actions/deploy-pages` actions to handle the deployment process.


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that deploys the static site to GitHub Pages
- document how to enable and trigger the Pages deployment from the repository settings

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68ca536b3a0483278a7b0b8de821f8e2